### PR TITLE
Allow modification of headers in HTMLResponse

### DIFF
--- a/Sources/HummingbirdElementary/HTMLResponse.swift
+++ b/Sources/HummingbirdElementary/HTMLResponse.swift
@@ -25,6 +25,9 @@ public struct HTMLResponse<Content: HTML & Sendable>: Sendable {
     /// The default is 1024 bytes.
     public var chunkSize: Int
 
+    /// Response headers
+    public var headers: HTTPFields = [.contentType: "text/html; charset=utf-8"]
+
     /// Creates a new HTMLResponse
     ///
     /// - Parameters:
@@ -49,7 +52,7 @@ extension HTMLResponse: ResponseGenerator {
     public consuming func response(from request: Request, context: some RequestContext) throws -> Response {
         .init(
             status: .ok,
-            headers: [.contentType: "text/html; charset=utf-8"],
+            headers: headers,
             body: .init { [self] writer in
                 try await self.content.render(into: StreamWriter(allocator: ByteBufferAllocator(), writer: writer), chunkSize: self.chunkSize)
                 try await writer.finish(nil)

--- a/Sources/HummingbirdElementary/HTMLResponse.swift
+++ b/Sources/HummingbirdElementary/HTMLResponse.swift
@@ -68,7 +68,7 @@ extension HTMLResponse: ResponseGenerator {
     public consuming func response(from request: Request, context: some RequestContext) throws -> Response {
         .init(
             status: .ok,
-            headers: headers,
+            headers: self.headers,
             body: .init { [self] writer in
                 try await self.content.render(into: StreamWriter(allocator: ByteBufferAllocator(), writer: writer), chunkSize: self.chunkSize)
                 try await writer.finish(nil)

--- a/Sources/HummingbirdElementary/HTMLResponse.swift
+++ b/Sources/HummingbirdElementary/HTMLResponse.swift
@@ -26,15 +26,31 @@ public struct HTMLResponse<Content: HTML & Sendable>: Sendable {
     public var chunkSize: Int
 
     /// Response headers
+    ///
+    /// It can be used to add additional headers to a predefined set of fields.
+    ///
+    /// - Note: If a new set of headers is assigned, all predefined headers are removed.
+    ///
+    /// ```swift
+    /// var response = HTMLResponse { ... }
+    /// response.headers[.init("foo")!] = "bar"
+    /// return response
+    /// ```
     public var headers: HTTPFields = [.contentType: "text/html; charset=utf-8"]
 
     /// Creates a new HTMLResponse
     ///
     /// - Parameters:
     ///   - chunkSize: The number of bytes to write to the response body at a time.
+    ///   - additionalHeaders: Additional headers to be merged with predefined headers.
     ///   - content: The `HTML` content to render in the response.
-    public init(chunkSize: Int = 1024, @HTMLBuilder content: () -> Content) {
+    public init(chunkSize: Int = 1024, additionalHeaders: HTTPFields = [:], @HTMLBuilder content: () -> Content) {
         self.chunkSize = chunkSize
+        if additionalHeaders.contains(.contentType) {
+            self.headers = additionalHeaders
+        } else {
+            self.headers = [.contentType: "text/html; charset=utf-8"] + additionalHeaders
+        }
         self.content = content()
     }
 }

--- a/Tests/HummingbirdElementaryTests/HTMLResponseTests.swift
+++ b/Tests/HummingbirdElementaryTests/HTMLResponseTests.swift
@@ -53,7 +53,7 @@ final class HTMLResponseTests: XCTestCase {
 
     func testRespondsWithCustomHeaders() async throws {
         let router = Router().get { _, _ in
-            var response = HTMLResponse { TestPage() }
+            var response = HTMLResponse(additionalHeaders: [.init("foo")!: "bar"]) { EmptyHTML() }
             response.headers[.init("hx-refresh")!] = "true"
             return response
         }
@@ -61,7 +61,21 @@ final class HTMLResponseTests: XCTestCase {
         try await Application(router: router).test(.router) { client in
             let response = try await client.execute(uri: "/", method: .get)
 
+            XCTAssertEqual(response.headers[.init("foo")!], "bar")
             XCTAssertEqual(response.headers[.init("hx-refresh")!], "true")
+            XCTAssertEqual(response.headers[.contentType], "text/html; charset=utf-8")
+        }
+    }
+
+    func testRespondsWithOverwrittenContentType() async throws {
+        let router = Router().get { _, _ in
+            HTMLResponse(additionalHeaders: [.contentType: "new"]) { EmptyHTML() }
+        }
+
+        try await Application(router: router).test(.router) { client in
+            let response = try await client.execute(uri: "/", method: .get)
+
+            XCTAssertEqual(response.headers[.contentType], "new")
         }
     }
 }

--- a/Tests/HummingbirdElementaryTests/HTMLResponseTests.swift
+++ b/Tests/HummingbirdElementaryTests/HTMLResponseTests.swift
@@ -50,6 +50,20 @@ final class HTMLResponseTests: XCTestCase {
             XCTAssertEqual(String(buffer: response.body), Array(repeating: "<p></p>", count: count).joined())
         }
     }
+
+    func testRespondsWithCustomHeaders() async throws {
+        let router = Router().get { _, _ in
+            var response = HTMLResponse { TestPage() }
+            response.headers[.init("hx-refresh")!] = "true"
+            return response
+        }
+
+        try await Application(router: router).test(.router) { client in
+            let response = try await client.execute(uri: "/", method: .get)
+
+            XCTAssertEqual(response.headers[.init("hx-refresh")!], "true")
+        }
+    }
 }
 
 struct TestPage: HTMLDocument {


### PR DESCRIPTION
This allows to set headers in HTMLResponse. It can be used like this:

```swift
Router().get { _, _ in
    var response = HTMLResponse { TestPage() }
    response.headers[.init("hx-refresh")!] = "true"
    return response
}
```

I'm unsure if we should add the headers to the initialiser too 🤔