### PR TITLE
added `status` field to `HTMLResponse` and its initializers

### DIFF
--- a/Sources/HummingbirdElementary/HTMLResponse.swift
+++ b/Sources/HummingbirdElementary/HTMLResponse.swift
@@ -3,8 +3,8 @@ import Hummingbird
 
 /// Represents a response that contains HTML content.
 ///
-/// The generated `Response` will have the content type header set to `text/html; charset=utf-8` and a status of `.ok`.
-/// The content is renederd in chunks of HTML and streamed in the response body.
+/// The generated `Response` will have the content type header set to `text/html; charset=utf-8` and a default status of `.ok`.
+/// The content is rendered in chunks of HTML and streamed in the response body.
 ///
 /// ```swift
 /// router.get { request, context in
@@ -20,6 +20,11 @@ import Hummingbird
 /// ```
 public struct HTMLResponse {
     private let value: _SendableAnyHTMLBox
+
+    /// The HTTP status code for the response.
+    ///
+    /// The default is `.ok`.
+    public var status: HTTPResponse.Status
 
     /// The number of bytes to write to the response body at a time.
     ///
@@ -42,10 +47,16 @@ public struct HTMLResponse {
     /// Creates a new HTMLResponse
     ///
     /// - Parameters:
+    ///   - status: The HTTP status code for the response.
     ///   - chunkSize: The number of bytes to write to the response body at a time.
     ///   - additionalHeaders: Additional headers to be merged with predefined headers.
     ///   - content: The `HTML` content to render in the response.
-    public init(chunkSize: Int = 1024, additionalHeaders: HTTPFields = [:], @HTMLBuilder content: () -> some HTML & Sendable) {
+    public init(
+        status: HTTPResponse.Status = .ok,
+        chunkSize: Int = 1024,
+        additionalHeaders: HTTPFields = [:],
+        @HTMLBuilder content: () -> some HTML & Sendable
+    ) {
         self.init(chunkSize: chunkSize, additionalHeaders: additionalHeaders, value: .init(content()))
     }
 
@@ -54,15 +65,22 @@ public struct HTMLResponse {
     /// Creates a new HTMLResponse
     ///
     /// - Parameters:
+    ///   - status: The HTTP status code for the response.
     ///   - chunkSize: The number of bytes to write to the response body at a time.
     ///   - additionalHeaders: Additional headers to be merged with predefined headers.
     ///   - content: The `HTML` content to render in the response.
-    public init(chunkSize: Int = 1024, additionalHeaders: HTTPFields = [:], @HTMLBuilder content: () -> sending some HTML) {
+    public init(
+        status: HTTPResponse.Status = .ok,
+        chunkSize: Int = 1024,
+        additionalHeaders: HTTPFields = [:],
+        @HTMLBuilder content: () -> sending some HTML
+    ) {
         self.init(chunkSize: chunkSize, additionalHeaders: additionalHeaders, value: .init(content()))
     }
     #endif
 
-    init(chunkSize: Int, additionalHeaders: HTTPFields = [:], value: _SendableAnyHTMLBox) {
+    init(status: HTTPResponse.Status = .ok, chunkSize: Int, additionalHeaders: HTTPFields = [:], value: _SendableAnyHTMLBox) {
+        self.status = status
         self.chunkSize = chunkSize
         if additionalHeaders.contains(.contentType) {
             self.headers = additionalHeaders
@@ -76,7 +94,7 @@ public struct HTMLResponse {
 extension HTMLResponse: ResponseGenerator {
     public consuming func response(from request: Request, context: some RequestContext) throws -> Response {
         .init(
-            status: .ok,
+            status: self.status,
             headers: self.headers,
             body: .init { [value, chunkSize] writer in
                 guard let html = value.tryTake() else {

--- a/Sources/HummingbirdElementary/HTMLResponse.swift
+++ b/Sources/HummingbirdElementary/HTMLResponse.swift
@@ -57,7 +57,7 @@ public struct HTMLResponse {
         additionalHeaders: HTTPFields = [:],
         @HTMLBuilder content: () -> some HTML & Sendable
     ) {
-        self.init(chunkSize: chunkSize, additionalHeaders: additionalHeaders, value: .init(content()))
+        self.init(status: status, chunkSize: chunkSize, additionalHeaders: additionalHeaders, value: .init(content()))
     }
 
     #if compiler(>=6.0)
@@ -75,7 +75,7 @@ public struct HTMLResponse {
         additionalHeaders: HTTPFields = [:],
         @HTMLBuilder content: () -> sending some HTML
     ) {
-        self.init(chunkSize: chunkSize, additionalHeaders: additionalHeaders, value: .init(content()))
+        self.init(status: status, chunkSize: chunkSize, additionalHeaders: additionalHeaders, value: .init(content()))
     }
     #endif
 

--- a/Tests/HummingbirdElementaryTests/HTMLResponseTests.swift
+++ b/Tests/HummingbirdElementaryTests/HTMLResponseTests.swift
@@ -56,6 +56,16 @@ final class HTMLResponseTests: XCTestCase {
         }
     }
 
+    func testRespondsWithCustomStatus() async throws {
+        let router = Router().get { _, _ in HTMLResponse(status: .created) { EmptyHTML() } }
+
+        try await Application(router: router).test(.router) { client in
+            let response = try await client.execute(uri: "/", method: .get)
+            XCTAssertEqual(response.status, .created)
+            XCTAssertEqual(response.headers[.contentType], "text/html; charset=utf-8")
+        }
+    }
+
     func testRespondsWithCustomHeaders() async throws {
         let router = Router().get { _, _ in
             var response = HTMLResponse(additionalHeaders: [.init("foo")!: "bar"]) { EmptyHTML() }


### PR DESCRIPTION
fixes #15

The newly added `status` parameter is also optional, so this shouldn't be a breaking change.