### PR TITLE
Remove throws keyword from ResponseGenerator conformance

### DIFF
--- a/Sources/HummingbirdElementary/HTMLResponse.swift
+++ b/Sources/HummingbirdElementary/HTMLResponse.swift
@@ -90,7 +90,7 @@ public struct HTMLResponse {
 }
 
 extension HTMLResponse: ResponseGenerator {
-    public consuming func response(from request: Request, context: some RequestContext) throws -> Response {
+    public consuming func response(from request: Request, context: some RequestContext) -> Response {
         .init(
             status: self.status,
             headers: self.headers,


### PR DESCRIPTION
I am adding RBAC to my forward authentication service and before this, the `auth` endpoint either responded with 204 (to signal that the user is authenticated and the request can be sent to the original target) or 302 to redirect to the login screen but I wanted to add a 403 page when the user is not in the group explaining what group they need to be in to access the page. And since get/post/etc. takes `some ResponseGenerator`, I need to convert HTMLResponse to Response manually to match the other return statements. Removing the throws keyword allows me to mark this get handler block with `throws(Never)`, since I don't have any other top level throws.